### PR TITLE
Copy actual slice values, instead of reflect Value structs.

### DIFF
--- a/D.go
+++ b/D.go
@@ -115,7 +115,7 @@ func copydata(val reflect.Value) interface{} {
 		arr := make([]interface{}, val.Len())
 
 		for i := 0; i < val.Len(); i++ {
-			arr[i] = recursecopy(val.Index(i))
+			arr[i] = recursecopy(val.Index(i).Interface())
 		}
 
 		return arr
@@ -326,7 +326,7 @@ func textrecurse(buffer io.Writer, wrap bool, data interface{}) error {
 	case reflect.Array:
 		fallthrough
 	case reflect.Slice:
-		_, e := fmt.Fprint(buffer, "[")
+		_, e := fmt.Fprint(buffer, "[ ")
 		if e != nil {
 			return e
 		}

--- a/D_test.go
+++ b/D_test.go
@@ -108,6 +108,16 @@ func TestCopyFrom(t *testing.T) {
 			v:  (D{"Field2": "Atad", "Field3": "Foo"}).CopyFrom(D{"Field1": "Data", "Field4": "Bar"}),
 			ex: "{\"Field1\":\"Data\",\"Field2\":\"Atad\",\"Field3\":\"Foo\",\"Field4\":\"Bar\"}",
 		},
+
+		{
+			v:  (D{}).CopyFrom([]string{"foo", "bar"}),
+			ex: `{"value":["foo","bar"]}`,
+		},
+
+		{
+			v:  (D{}).CopyFrom(D{"baz": []string{"foo", "bar"}}),
+			ex: `{"baz":["foo","bar"]}`,
+		},
 	}
 
 	runcases_d(tests, t)


### PR DESCRIPTION
Previously, `D` would copy the `reflect.Value` struct of each slice
value, instead of the value itself.