### PR TITLE
Allow usage on Google App Engine, adds AppEngineOutput driver.

### DIFF
--- a/AppEngineOutput.go
+++ b/AppEngineOutput.go
@@ -1,0 +1,57 @@
+// +build appengine
+
+package logberry
+
+import (
+	"appengine"
+)
+
+// AppEngineOutput is an OutputDriver that writes out log events in a more or
+// less human readable form, using an App Engine context from a request.
+type AppEngineOutput struct {
+	root *Root
+	ctx  appengine.Context
+}
+
+// NewAppEngineOutput creates a new AppEngineOutput logging to the given
+// appengine context.
+func NewAppEngineOutput(ctx appengine.Context) *AppEngineOutput {
+	return &AppEngineOutput{ctx: ctx}
+}
+
+// Attach notifies the OutputDriver of its Root.  It should only be
+// called by a Root.
+func (d *AppEngineOutput) Attach(root *Root) {
+	d.root = root
+}
+
+// Detach notifies the OutputDriver that it has been removed from its
+// Root.  It should only be called by a root.
+func (d *AppEngineOutput) Detach() {
+	d.root = nil
+}
+
+// Event outputs a generated log entry, as called by a Root or a
+// chaining OutputDriver.
+func (d *AppEngineOutput) Event(evt *Event) {
+	if d.ctx == nil {
+		d.root.InternalError(NewError("no AppEngine context attached to output driver"))
+		return
+	}
+
+	var logFunc func(string, ...interface{})
+
+	switch evt.Event {
+	case WARNING:
+		logFunc = d.ctx.Warningf
+
+	case ERROR:
+		logFunc = d.ctx.Errorf
+
+	default:
+		logFunc = d.ctx.Infof
+	}
+
+	logFunc("%v %v (%v:%v): %v %v", evt.Event, evt.Component, evt.TaskID,
+		evt.ParentID, evt.Message, evt.Data.String())
+}

--- a/TextOutput.go
+++ b/TextOutput.go
@@ -1,3 +1,5 @@
+// +build !appengine
+
 package logberry
 
 import (

--- a/package.go
+++ b/package.go
@@ -1,3 +1,5 @@
+// +build !appengine
+
 /*
 Package logberry implements a structured logging framework.  It is
 focused on generating logs, rather than managing them, and tries to be

--- a/package_appengine.go
+++ b/package_appengine.go
@@ -1,0 +1,24 @@
+// +build appengine
+
+package logberry
+
+import (
+	"appengine"
+)
+
+var Std *Root
+var Main *Task
+
+// NewRootTask creates a new root, defaulting to an AppEngineOutput driver,
+// logging to a given task.  This is necessary, since any output an App Engine
+// program does needs to be done using a context from a request.
+func NewRootTask(ctx appengine.Context) (*Root, *Task) {
+	root := NewRoot(24)
+	root.AddOutputDriver(NewAppEngineOutput(ctx))
+
+	return root, &Task{
+		component: "main",
+		activity:  "Component main",
+		root:      root,
+	}
+}


### PR DESCRIPTION
Go programs on Google App Engine cannot import the `syscall` package.
Therefore, `TextOutput` (and `package.go`) cannot be built.  This adds a
build tag such that App Engine ignores these files, and instead builds
`AppEngineOutput`.  Any logging output done by a Go App Engine program
needs to be done with a context instance given at the start of each
request.  `AppEngineOutput` handles this.