### PR TITLE
Don't write anything for an empty EventDataMap.

### DIFF
--- a/EventData.go
+++ b/EventData.go
@@ -28,6 +28,10 @@ func (x EventDataMap) String() string {
 
 func (x EventDataMap) WriteTo(out io.Writer) {
 
+	if len(x) == 0 {
+		return
+	}
+
 	fmt.Fprintf(out, "{")
 
 	keys := make([]string, len(x))


### PR DESCRIPTION
This quiets `{ }` noise when tasks don't have any additional data.